### PR TITLE
Select whole trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ After a trace is recorded you can open it with the visualizer. Just select the t
 
 ![Choose file](docs/FileSelect.png)
 
-Arrows and message labels are clickable!
+Click on an arrow or message label to see the raw trace object.
+Alt+click on the arrow to select all trace's arrows.

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     >
       <button id="settings-button">Open Settings</button>
       <button id="clear-button">Clear</button>
-      <button onclick="document.getElementById('file-selector').click();">Select file</button>
+      <button id="select-file-button">Select file</button>
       <input id="file-selector" type="file" style="display: none;" />
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,8 @@
     >
       <button id="settings-button">Open Settings</button>
       <button id="clear-button">Clear</button>
-      <input id="file-selector" type="file" />
+      <button onclick="document.getElementById('file-selector').click();">Select file</button>
+      <input id="file-selector" type="file" style="display: none;" />
     </div>
 
     <div

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import {createTooltipClosure} from "./ts/Tooltip";
+import {bindLineOnClick as createLineClickHandlerFactory} from "./ts/Tooltip";
 import {MessageData} from "./ts/Types/MessageData";
 import {
   CLASS_WIDTH,
@@ -148,7 +148,7 @@ function processData(data: Array<MessageData>) {
   });
 
   // Append div with tooltip
-  const showTooltipClosure = createTooltipClosure();
+  const lineClickHandlerFactory = createLineClickHandlerFactory();
 
   // Draw message arrows
   const colorSelector = arrowColorSelector(settings, data);
@@ -170,7 +170,7 @@ function processData(data: Array<MessageData>) {
       .style("stroke", "rgba(0,0,0,0)")
       .style("cursor", "pointer")
       .style("stroke-width", "5px");
-    clickPath.on("click", showTooltipClosure(m, path));
+    clickPath.on("click", lineClickHandlerFactory(m, path));
     if (m.payloadType === RESPONSE_TYPE) {
       path.style("stroke-dasharray", "5, 3");
     }
@@ -185,7 +185,7 @@ function processData(data: Array<MessageData>) {
       .style("font-size", "13px")
       .style("cursor", "pointer")
       .text(() => m.label)
-      .on("click", showTooltipClosure(m, path));
+      .on("click", lineClickHandlerFactory(m, path));
   });
 
   // Draw message timestamps

--- a/src/ts/Settings.ts
+++ b/src/ts/Settings.ts
@@ -72,3 +72,6 @@ document.querySelector<HTMLButtonElement>("#button-apply-settings")
     settings.apply();
     window.dispatchEvent(new UpdateEvent(settings))
   });
+
+document.getElementById("select-file-button")
+  ?.addEventListener("click", () => document.getElementById('file-selector')?.click());

--- a/src/ts/Tooltip.ts
+++ b/src/ts/Tooltip.ts
@@ -1,10 +1,10 @@
 import * as d3 from "d3-selection";
-import {DEFAULT_STROKE_WIDTH, SELECTED_STROKE_WIDTH} from "./Constants";
+import { DEFAULT_STROKE_WIDTH, SELECTED_STROKE_WIDTH } from "./Constants";
 
 /**
  * @return {function(*, *): function(): void}
  */
-export function createTooltipClosure() {
+export function bindLineOnClick() {
   const container = d3.select("#tooltip-container");
 
   let tooltipDiv: any = d3.select("div[class='tooltip']");
@@ -66,8 +66,24 @@ export function createTooltipClosure() {
       fakeBox.on("click", null).style("display", "none");
     }
 
+    function selectWholeTraceOnAltClick() {
+      const traceId = line.attr("trace-id");
+      const allArrows = d3.selectAll(`path[trace-id='${traceId}']`);
+      fakeBox.on("click", () => {
+        allArrows
+          .transition()
+          .style("stroke-width", DEFAULT_STROKE_WIDTH);
+        fakeBox.on("click", null).style("display", "none");
+      }).style("display", "block");
+      allArrows
+        .transition()
+        .style("stroke-width", SELECTED_STROKE_WIDTH);
+    }
+
     return () => {
-      if (tooltipDiv.attr("show") === "true") {
+      if ((d3.event as MouseEvent).altKey) {
+        selectWholeTraceOnAltClick();
+      } else if (tooltipDiv.attr("show") === "true") {
         hide();
       } else {
         show();

--- a/src/ts/TraceSelector.ts
+++ b/src/ts/TraceSelector.ts
@@ -1,5 +1,5 @@
-import {settings} from "./Settings";
-import {UpdateEvent} from "./Events/Update";
+import { settings } from "./Settings";
+import { UpdateEvent } from "./Events/Update";
 
 export function initTraceSelectors(document: Document) {
   document.querySelector<HTMLButtonElement>("#clear-button")
@@ -15,8 +15,11 @@ export function initTraceSelectors(document: Document) {
     });
 
   document.querySelector<HTMLInputElement>("#file-selector")
-    ?.addEventListener("change", () => {
+    ?.addEventListener("change", (e: Event) => {
       settings.apply();
       window.dispatchEvent(new UpdateEvent(settings));
+      if ((e.target as HTMLInputElement)?.value !== undefined) {
+        (e.target as HTMLInputElement).value = '';
+      }
     });
 }


### PR DESCRIPTION
Add alt+lmb click to select all trace arrows — useful when you need to scroll
![image](https://user-images.githubusercontent.com/16411561/138607709-d8eb7924-dc00-4425-8ebf-37b56fb5b110.png)

fix bug when you can't reload file with the same name